### PR TITLE
test-configs.yaml: add broonie-misc filters

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -535,6 +535,13 @@ build_configs:
   broonie-misc:
     tree: broonie-misc
     branch: 'for-kernelci'
+    variants:
+      gcc-8:
+        build_environment: gcc-8
+        architectures:
+          arm: {base_defconfig: 'multi_v7_defconfig'}
+          arm64:
+          x86_64:
 
   broonie-regmap:
     tree: broonie-regmap


### PR DESCRIPTION
Add filters to the broonie-misc build configuration to only cover the
architectures with boards available to run tests (arm, arm64, x86_64),
and don't enable special all*configs or extra fragments.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>