### PR TITLE
build-configs.yaml: add ARM64_64K_PAGES to gcc-8

### DIFF
--- a/build-configs.yaml
+++ b/build-configs.yaml
@@ -680,7 +680,14 @@ build_configs:
           mips: *mips_arch
           riscv: *riscv_arch
           arc: *arc_arch
-          arm64: *arm64_arch
+          arm64:
+            <<: *arm64_arch
+            extra_configs:
+              - 'allmodconfig'
+              - 'allnoconfig'
+              - 'defconfig+CONFIG_ARM64_64K_PAGES'
+              - 'defconfig+CONFIG_CPU_BIG_ENDIAN=y'
+              - 'defconfig+CONFIG_RANDOMIZE_BASE=y'
           arm:
             base_defconfig: 'multi_v7_defconfig'
             extra_configs:
@@ -696,8 +703,8 @@ build_configs:
           arm64:
             extra_configs:
               - 'allmodconfig'
-              - 'defconfig+CONFIG_ARM64_64K_PAGES'
               - 'allnoconfig'
+              - 'defconfig+CONFIG_ARM64_64K_PAGES'
           arm:
             base_defconfig: 'multi_v7_defconfig'
             filters:


### PR DESCRIPTION
Enable defconfig+CONFIG_ARM64_64K_PAGES with gcc-8 as well as clang-9.

This is a follow-up from the fact that enabling extra config options
was not possible clang due to an issue with merge_config.sh which has
now been resolved thanks to the LLVM=1 variable.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>